### PR TITLE
feat: add search routing via URL params

### DIFF
--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -4,7 +4,7 @@
  * Custom hook to manage recent search history in localStorage.
  */
 
-import { useState, useCallback } from 'react';
+import { createContext, useState, useCallback } from 'react';
 import type { FilterState } from '@/models/AppTypes';
 
 const STORAGE_KEY = 'findthagame_recent_searches';
@@ -43,6 +43,10 @@ const loadSearches = (): RecentSearch[] => {
 const saveSearches = (searches: RecentSearch[]): void => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(searches));
 };
+
+export const RecentSearchesContext = createContext<{
+  addSearch: (filters: FilterState, resultCount: number) => void;
+} | null>(null);
 
 export const useRecentSearches = () => {
   // Lazy initial state to load from localStorage

--- a/src/lib/searchParams.ts
+++ b/src/lib/searchParams.ts
@@ -1,0 +1,82 @@
+import type { FilterState } from '@/models/AppTypes';
+
+interface RawSearchParams {
+  q?: string;
+  p?: string;
+  yr0?: string;
+  yr1?: string;
+  g?: string;
+  t?: string;
+  gm?: string;
+  pr?: string;
+  c?: string;
+  s?: string;
+  dev?: string;
+  mr?: string;
+  arO?: string;
+  arV?: string;
+}
+
+const parseNumArray = (val: string | undefined): number[] => {
+  if (!val) return [];
+  return val.split(',').map(Number).filter((n) => !isNaN(n));
+};
+
+const numArrayToString = (arr: number[]): string | undefined => {
+  return arr.length > 0 ? arr.join(',') : undefined;
+};
+
+const optNum = (val: string | undefined): number | null => {
+  if (val === undefined || val === '') return null;
+  const n = parseInt(val, 10);
+  return isNaN(n) ? null : n;
+};
+
+export const filterToSearchParams = (filter: FilterState): Record<string, string> => {
+  const params: Record<string, string> = {};
+
+  if (filter.search) params.q = filter.search;
+  if (filter.platformId !== null) params.p = String(filter.platformId);
+  if (filter.yearRange[0] !== 1970) params.yr0 = String(filter.yearRange[0]);
+  if (filter.yearRange[1] !== 2026) params.yr1 = String(filter.yearRange[1]);
+  const g = numArrayToString(filter.genreIds);
+  if (g) params.g = g;
+  const t = numArrayToString(filter.themeIds);
+  if (t) params.t = t;
+  if (filter.gameModeId !== null) params.gm = String(filter.gameModeId);
+  if (filter.perspectiveId !== null) params.pr = String(filter.perspectiveId);
+  if (filter.categoryId !== null) params.c = String(filter.categoryId);
+  if (filter.statusId !== null) params.s = String(filter.statusId);
+  if (filter.developerName) params.dev = filter.developerName;
+  if (filter.minRating !== null) params.mr = String(filter.minRating);
+  if (filter.ageRatingOrg !== null) params.arO = String(filter.ageRatingOrg);
+  if (filter.ageRatingValue !== null) params.arV = String(filter.ageRatingValue);
+
+  return params;
+};
+
+export const searchParamsToFilter = (params: Record<string, unknown>): FilterState => {
+  const raw = params as RawSearchParams;
+  return {
+    search: raw.q ?? '',
+    platformId: optNum(raw.p),
+    yearRange: [
+      raw.yr0 !== undefined ? (parseInt(raw.yr0, 10) || 1970) : 1970,
+      raw.yr1 !== undefined ? (parseInt(raw.yr1, 10) || 2026) : 2026,
+    ],
+    genreIds: parseNumArray(raw.g),
+    themeIds: parseNumArray(raw.t),
+    gameModeId: optNum(raw.gm),
+    perspectiveId: optNum(raw.pr),
+    categoryId: optNum(raw.c),
+    statusId: optNum(raw.s),
+    developerName: raw.dev ?? '',
+    minRating: optNum(raw.mr),
+    ageRatingOrg: optNum(raw.arO),
+    ageRatingValue: optNum(raw.arV),
+  };
+};
+
+export const hasAnyFilter = (params: Record<string, unknown>): boolean => {
+  return Object.keys(params).length > 0;
+};

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,20 +1,20 @@
-import React, { useState, Suspense } from 'react';
+import React, { useState, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector, useDispatch } from 'react-redux';
-import { createRootRoute, Outlet, ScrollRestoration, useNavigate } from '@tanstack/react-router';
+import { createRootRoute, Outlet, ScrollRestoration, useNavigate, useRouterState } from '@tanstack/react-router';
 import type { RootState } from '@/store/store';
-import { setLoading, setResults, setError, selectExternalGame } from '@/store/slices/resultsSlice';
+import { selectExternalGame } from '@/store/slices/resultsSlice';
 import { setAllFilters, resetFilters } from '@/store/slices/detectiveSlice';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { FilterPanel } from '@/features/dashboard/filterPanel';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Search } from 'lucide-react';
-import { searchGames } from '@/api/client';
-import { useRecentSearches, type RecentSearch } from '@/hooks/useRecentSearches';
+import { useRecentSearches, RecentSearchesContext, type RecentSearch } from '@/hooks/useRecentSearches';
 import { useFavorites } from '@/hooks/useFavorites';
 import { FavoritesDialog } from '@/components/FavoritesDialog';
 import { SavedSearchesDialog } from '@/components/SavedSearchesDialog';
+import { filterToSearchParams } from '@/lib/searchParams';
 import type { FilterState, GameResult } from '@/models/AppTypes';
 import { generateRandomFilters } from '@/utils/randomFilters';
 
@@ -35,6 +35,7 @@ function RootLayout() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const routerState = useRouterState();
 
   const results = useSelector((state: RootState) => state.results.items);
   const status = useSelector((state: RootState) => state.results.status);
@@ -59,63 +60,35 @@ function RootLayout() {
 
   const isLoading = status === 'loading';
 
-  const handleSearch = async (filtersState: FilterState) => {
-    setMobileOpen(false);
-    dispatch(setLoading());
-    navigate({ to: '/' });
-
-    const fullFilters = { ...filtersState, search: searchTerm };
-
-    try {
-      const data = await searchGames(fullFilters);
-      dispatch(setResults(data));
-      addSearch(fullFilters, data.length);
-      setTimeout(() => {
-        document.getElementById('results-area')?.scrollIntoView({ behavior: 'smooth' });
-      }, 50);
-    } catch (err) {
-      console.error('Search failed:', err);
-      dispatch(setError(err instanceof Error ? err.message : 'Search failed'));
+  // Restore searchTerm from URL when navigating back to a search
+  useEffect(() => {
+    const locationSearch = routerState.location.search as Record<string, unknown>;
+    const urlQ = typeof locationSearch.q === 'string' ? locationSearch.q : '';
+    if (urlQ && urlQ !== searchTerm) {
+      setSearchTerm(urlQ);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [(routerState.location.search as Record<string, unknown>).q]);
+
+  const handleSearch = (filtersState: FilterState) => {
+    setMobileOpen(false);
+    const fullFilters = { ...filtersState, search: searchTerm };
+    navigate({ to: '/', search: filterToSearchParams(fullFilters) });
   };
 
-  const handleSelectRecentSearch = async (search: RecentSearch) => {
+  const handleSelectRecentSearch = (search: RecentSearch) => {
     setSearchTerm(search.filters.search);
     dispatch(setAllFilters(search.filters));
     setMobileOpen(false);
-    dispatch(setLoading());
-    navigate({ to: '/' });
-
-    try {
-      const data = await searchGames(search.filters);
-      dispatch(setResults(data));
-      setTimeout(() => {
-        document.getElementById('results-area')?.scrollIntoView({ behavior: 'smooth' });
-      }, 50);
-    } catch (err) {
-      console.error('Search failed:', err);
-      dispatch(setError(err instanceof Error ? err.message : 'Search failed'));
-    }
+    navigate({ to: '/', search: filterToSearchParams(search.filters) });
   };
 
-  const handleRandomize = async () => {
+  const handleRandomize = () => {
     const randomFilters = generateRandomFilters();
     dispatch(setAllFilters(randomFilters));
     setMobileOpen(false);
-    dispatch(setLoading());
-    navigate({ to: '/' });
-
-    try {
-      const data = await searchGames(randomFilters);
-      dispatch(setResults(data));
-      addSearch(randomFilters, data.length);
-      setTimeout(() => {
-        document.getElementById('results-area')?.scrollIntoView({ behavior: 'smooth' });
-      }, 50);
-    } catch (err) {
-      console.error('Random search failed:', err);
-      dispatch(setError(err instanceof Error ? err.message : 'Search failed'));
-    }
+    setSearchTerm('');
+    navigate({ to: '/', search: filterToSearchParams(randomFilters) });
   };
 
   const handleSelectFavorite = (game: GameResult) => {
@@ -189,27 +162,29 @@ function RootLayout() {
 
   return (
     <>
-      <DashboardLayout
-        brandHeader={brandHeader}
-        searchBar={searchBar}
-        mobileSearch={mobileSearch}
-        sidebar={sidebar}
-        main={<Outlet />}
-        isMobileOpen={isMobileOpen}
-        onMobileToggle={() => setMobileOpen(!isMobileOpen)}
-        isSidebarCollapsed={isSidebarCollapsed}
-        onSidebarToggle={() => setSidebarCollapsed(!isSidebarCollapsed)}
-        isLoading={isLoading}
-        resultsCount={results.length}
-        recentSearches={recentSearches}
-        onSelectSearch={handleSelectRecentSearch}
-        onDeleteSearch={removeSearch}
-        onClearHistory={clearSearchHistory}
-        onToggleBookmark={toggleBookmark}
-        onRandomize={handleRandomize}
-        onOpenFavorites={handleOpenFavorites}
-        onOpenSavedSearches={handleOpenSavedSearches}
-      />
+      <RecentSearchesContext.Provider value={{ addSearch }}>
+        <DashboardLayout
+          brandHeader={brandHeader}
+          searchBar={searchBar}
+          mobileSearch={mobileSearch}
+          sidebar={sidebar}
+          main={<Outlet />}
+          isMobileOpen={isMobileOpen}
+          onMobileToggle={() => setMobileOpen(!isMobileOpen)}
+          isSidebarCollapsed={isSidebarCollapsed}
+          onSidebarToggle={() => setSidebarCollapsed(!isSidebarCollapsed)}
+          isLoading={isLoading}
+          resultsCount={results.length}
+          recentSearches={recentSearches}
+          onSelectSearch={handleSelectRecentSearch}
+          onDeleteSearch={removeSearch}
+          onClearHistory={clearSearchHistory}
+          onToggleBookmark={toggleBookmark}
+          onRandomize={handleRandomize}
+          onOpenFavorites={handleOpenFavorites}
+          onOpenSavedSearches={handleOpenSavedSearches}
+        />
+      </RecentSearchesContext.Provider>
       
       <FavoritesDialog
         open={isFavoritesOpen}

--- a/src/routes/game.$gameId.tsx
+++ b/src/routes/game.$gameId.tsx
@@ -44,9 +44,9 @@ function GameDetailPage() {
     setTimeout(() => {
       dispatch(clearSelection());
       setIsExiting(false);
-      navigate({ to: '/' });
+      window.history.back();
     }, 300);
-  }, [dispatch, navigate]);
+  }, [dispatch]);
 
   const handlePrev = useCallback(() => {
     if (selectedIndex !== null && selectedIndex > 0) {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,7 @@ import { RecentSearchesContext } from '@/hooks/useRecentSearches';
 import type { FilterState } from '@/models/AppTypes';
 
 let savedScrollPosition = 0;
+let lastSearchedUrlKey = '';
 
 export const Route = createFileRoute('/')({
   component: SearchResultsPage,
@@ -42,16 +43,15 @@ function SearchResultsPage() {
 
   const searchKey = JSON.stringify(rawSearch);
   const latestRequestId = useRef(0);
-  const lastSearchedParams = useRef('');
 
   useEffect(() => {
     if (!hasParams) return;
-    if (searchKey === lastSearchedParams.current) return;
+    if (searchKey === lastSearchedUrlKey) return;
 
     const state = store.getState();
     if (state.results.status === 'loading') return;
 
-    lastSearchedParams.current = searchKey;
+    lastSearchedUrlKey = searchKey;
     const requestId = ++latestRequestId.current;
 
     dispatch(setAllFilters(filter as FilterState));

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -42,31 +42,16 @@ function SearchResultsPage() {
 
   const searchKey = JSON.stringify(rawSearch);
   const latestRequestId = useRef(0);
+  const lastSearchedParams = useRef('');
 
   useEffect(() => {
     if (!hasParams) return;
+    if (searchKey === lastSearchedParams.current) return;
 
     const state = store.getState();
     if (state.results.status === 'loading') return;
 
-    const currentFilters = state.detective as FilterState;
-    const filtersMatch =
-      filter.search === currentFilters.search &&
-      filter.platformId === currentFilters.platformId &&
-      JSON.stringify(filter.yearRange) === JSON.stringify(currentFilters.yearRange) &&
-      JSON.stringify(filter.genreIds) === JSON.stringify(currentFilters.genreIds) &&
-      JSON.stringify(filter.themeIds) === JSON.stringify(currentFilters.themeIds) &&
-      filter.gameModeId === currentFilters.gameModeId &&
-      filter.perspectiveId === currentFilters.perspectiveId &&
-      filter.categoryId === currentFilters.categoryId &&
-      filter.statusId === currentFilters.statusId &&
-      filter.developerName === currentFilters.developerName &&
-      filter.minRating === currentFilters.minRating &&
-      filter.ageRatingOrg === currentFilters.ageRatingOrg &&
-      filter.ageRatingValue === currentFilters.ageRatingValue;
-
-    if (filtersMatch && state.results.status === 'success') return;
-
+    lastSearchedParams.current = searchKey;
     const requestId = ++latestRequestId.current;
 
     dispatch(setAllFilters(filter as FilterState));

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,16 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef, useLayoutEffect, useContext, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import type { RootState } from '@/store/store';
-import { selectGame, setCurrentPage, setSortBy } from '@/store/slices/resultsSlice';
+import { createFileRoute, useNavigate, useElementScrollRestoration, useRouterState } from '@tanstack/react-router';
+import { store, type RootState } from '@/store/store';
+import { selectGame, setCurrentPage, setSortBy, setLoading, setResults, setError } from '@/store/slices/resultsSlice';
+import { setAllFilters } from '@/store/slices/detectiveSlice';
 import { ResultsGrid } from '@/features/dashboard/ResultsGrid';
+import { searchGames } from '@/api/client';
+import { searchParamsToFilter, hasAnyFilter } from '@/lib/searchParams';
+import { RecentSearchesContext } from '@/hooks/useRecentSearches';
+import type { FilterState } from '@/models/AppTypes';
+
+let savedScrollPosition = 0;
 
 export const Route = createFileRoute('/')({
   component: SearchResultsPage,
@@ -12,6 +19,12 @@ export const Route = createFileRoute('/')({
 function SearchResultsPage() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const routerState = useRouterState();
+  const recentSearchesCtx = useContext(RecentSearchesContext);
+
+  const rawSearch = (routerState.location.search as Record<string, unknown>) ?? {};
+  const hasParams = hasAnyFilter(rawSearch);
+  const filter = searchParamsToFilter(rawSearch);
 
   const results = useSelector((state: RootState) => state.results.items);
   const status = useSelector((state: RootState) => state.results.status);
@@ -27,6 +40,55 @@ function SearchResultsPage() {
     localStorage.setItem('resultsViewMode', mode);
   };
 
+  const searchKey = JSON.stringify(rawSearch);
+  const latestRequestId = useRef(0);
+
+  useEffect(() => {
+    if (!hasParams) return;
+
+    const state = store.getState();
+    if (state.results.status === 'loading') return;
+
+    const currentFilters = state.detective as FilterState;
+    const filtersMatch =
+      filter.search === currentFilters.search &&
+      filter.platformId === currentFilters.platformId &&
+      JSON.stringify(filter.yearRange) === JSON.stringify(currentFilters.yearRange) &&
+      JSON.stringify(filter.genreIds) === JSON.stringify(currentFilters.genreIds) &&
+      JSON.stringify(filter.themeIds) === JSON.stringify(currentFilters.themeIds) &&
+      filter.gameModeId === currentFilters.gameModeId &&
+      filter.perspectiveId === currentFilters.perspectiveId &&
+      filter.categoryId === currentFilters.categoryId &&
+      filter.statusId === currentFilters.statusId &&
+      filter.developerName === currentFilters.developerName &&
+      filter.minRating === currentFilters.minRating &&
+      filter.ageRatingOrg === currentFilters.ageRatingOrg &&
+      filter.ageRatingValue === currentFilters.ageRatingValue;
+
+    if (filtersMatch && state.results.status === 'success') return;
+
+    const requestId = ++latestRequestId.current;
+
+    dispatch(setAllFilters(filter as FilterState));
+    dispatch(setLoading());
+
+    searchGames(filter as FilterState)
+      .then((data) => {
+        if (requestId !== latestRequestId.current) return;
+        dispatch(setResults(data));
+        recentSearchesCtx?.addSearch(filter as FilterState, data.length);
+        setTimeout(() => {
+          document.getElementById('results-area')?.scrollIntoView({ behavior: 'smooth' });
+        }, 50);
+      })
+      .catch((err) => {
+        if (requestId !== latestRequestId.current) return;
+        console.error('Search failed:', err);
+        dispatch(setError(err instanceof Error ? err.message : 'Search failed'));
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchKey, hasParams]);
+
   const handleSortByChange = useCallback((val: string) => {
     dispatch(setSortBy(val));
   }, [dispatch]);
@@ -34,6 +96,7 @@ function SearchResultsPage() {
   const handleSelectGame = useCallback((index: number, origin: { x: number; y: number; width: number; height: number }) => {
     const game = results[index];
     if (game) {
+      savedScrollPosition = containerRef.current?.scrollTop ?? 0;
       dispatch(selectGame({ index, origin }));
       navigate({ to: '/game/$gameId', params: { gameId: game.id.toString() } });
     }
@@ -45,8 +108,35 @@ function SearchResultsPage() {
 
   const isLoading = status === 'loading';
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollEntry = useElementScrollRestoration({ id: 'results-area' });
+
+  useLayoutEffect(() => {
+    if (status === 'loading') {
+      savedScrollPosition = 0;
+      return;
+    }
+
+    if (!containerRef.current || results.length === 0) return;
+
+    if (scrollEntry && (scrollEntry.scrollY > 0 || scrollEntry.scrollX > 0)) {
+      containerRef.current.scrollTo({
+        left: scrollEntry.scrollX,
+        top: scrollEntry.scrollY,
+        behavior: 'instant',
+      });
+    } else if (savedScrollPosition > 0) {
+      containerRef.current.scrollTop = savedScrollPosition;
+    }
+  }, [scrollEntry, results, status]);
+
   return (
-    <div id="results-area" className="w-full h-full overflow-y-auto px-4 md:px-6 py-6">
+    <div 
+      id="results-area" 
+      ref={containerRef}
+      data-scroll-restoration-id="results-area"
+      className="w-full h-full overflow-y-auto px-4 md:px-6 py-6"
+    >
       <ResultsGrid 
         results={results}
         isLoading={isLoading}


### PR DESCRIPTION
Encode search filters as URL search params so searches are bookmarkable, shareable, and browser back/forward navigable.

- Add src/lib/searchParams.ts: FilterState <-> compact URL params
- Index route now reads URL params and triggers search execution
- Root layout handlers simplified to just navigate with params
- Export RecentSearchesContext for index route to add to history